### PR TITLE
Release 1.3.1: STA client mode, credential reset & HTTP/SPI hardening

### DIFF
--- a/front/www/html/config.html
+++ b/front/www/html/config.html
@@ -556,6 +556,21 @@
             connects to your Wi-Fi network as a client. You can then also access the
             UberLogger through the IP address assigned by your DHCP server.
           </label>
+
+          <input
+            id="wifi_mode_sta"
+            name="WIFI_MODE"
+            class="element radio json-as-number"
+            type="radio"
+            value="2"
+            onclick="wifiConfigVisibilityUpdate();"
+          />
+          <label class="choice" for="wifi_mode_sta">
+            Client mode only<br />UberLogger connects to your Wi-Fi network as a
+            client and the hotspot is disabled. Access the device through the IP
+            address assigned by your DHCP server. If the network is unreachable,
+            hold the MODE button for 5 seconds to fall back to hotspot-only mode.
+          </label>
         </span>
 
         <div id="wifi_client_settings">

--- a/front/www/js/config.js
+++ b/front/www/js/config.js
@@ -185,11 +185,12 @@ function testWifiNetwork() {
 function wifiConfigVisibilityUpdate() {
   var show_parameters = $("input[name='WIFI_MODE']:checked").val();
 
-  if (show_parameters == "1") {
+  // Show client (STA) settings for both Hotspot+Client (1) and Client-only (2)
+  if (show_parameters == "1" || show_parameters == "2") {
     document.querySelector("#wifi_client_settings").style.display =
-      "inline-block"; // hide parameters
+      "inline-block";
   } else {
-    document.querySelector("#wifi_client_settings").style.display = "none"; // show parameters
+    document.querySelector("#wifi_client_settings").style.display = "none";
   }
 }
 

--- a/main/hmi.c
+++ b/main/hmi.c
@@ -151,12 +151,23 @@ void task_hmi(void* ignore) {
             case MODEBUTTON_HOLD:
                 // if held for longer than 5 seconds, we will put the system to SoftAP mode
                 // ESP_LOGI(TAG, "Button held for %ld ms", 10*(xTaskGetTickCount() - startTick));
-                if ((xTaskGetTickCount() - startTick) > 500 && 
+                if ((xTaskGetTickCount() - startTick) > 500 &&
                     longPush == 0 )
                 {
-                    Logger_mode_button_long_pushed();  
+                    if (Logger_mode_button_long_pushed())
+                    {
+                        // Credentials were reset to defaults: flash both LEDs
+                        // together a few times so the user gets clear visual
+                        // confirmation that the reset happened.
+                        for (uint8_t i = 0; i < 6; i++)
+                        {
+                            gpio_set_level(GPIO_HMI_LED_GREEN, i & 1);
+                            gpio_set_level(GPIO_HMI_LED_RED, i & 1);
+                            vTaskDelay(150 / portTICK_PERIOD_MS);
+                        }
+                    }
                     longPush = 1;
-                } 
+                }
             break;
 
             case MODEBUTTON_RELEASED:

--- a/main/logger.c
+++ b/main/logger.c
@@ -876,9 +876,27 @@ esp_err_t Logger_syncSettings(uint8_t syncTime)
     return ESP_OK;
 }
 
+// True when the logger is sitting in a settled, non-busy state: idle or a
+// momentary single-shot (which immediately drops back to idle). Used to gate
+// operations that require a known-good state -- settings sync, calibration,
+// firmware update, the external auto-trigger.
+static bool Logger_state_is_settled(void)
+{
+    LoggerState_t s = _currentLogTaskState;
+    return (s == LOGTASK_IDLE) || (s == LOGTASK_SINGLE_SHOT);
+}
+
+// True when the logger is settled OR recovering from an error. Used to gate
+// user-initiated recovery actions that should still work after a fault:
+// start logging, format the SD card, reset credentials.
+static bool Logger_state_allows_recovery_action(void)
+{
+    return Logger_state_is_settled() || (_currentLogTaskState == LOGTASK_ERROR_OCCURED);
+}
+
 esp_err_t Logtask_sync_settings()
 {
-    if (_currentLogTaskState != LOGTASK_IDLE && _currentLogTaskState != LOGTASK_SINGLE_SHOT)
+    if (!Logger_state_is_settled())
     {
         ESP_LOGE(TAG_LOG, "Cannot sync settings while logging or calibration. State = %u", _currentLogTaskState);
         return ESP_FAIL;
@@ -966,9 +984,7 @@ uint8_t Logger_getCsvLog()
 void Logger_mode_button_pushed()
 {
 
-    if ((_currentLogTaskState == LOGTASK_IDLE || 
-        _currentLogTaskState == LOGTASK_ERROR_OCCURED || 
-        _currentLogTaskState == LOGTASK_SINGLE_SHOT) && 
+    if (Logger_state_allows_recovery_action() &&
         (settings_get_ext_trigger_mode() != TRIGGER_MODE_EXTERNAL_CONTROL))
     {
         LogTask_start();
@@ -984,9 +1000,7 @@ void Logger_mode_button_pushed()
 
 bool Logger_mode_button_long_pushed()
 {
-    if (_currentLogTaskState == LOGTASK_IDLE ||
-        _currentLogTaskState == LOGTASK_ERROR_OCCURED ||
-        _currentLogTaskState == LOGTASK_SINGLE_SHOT)
+    if (Logger_state_allows_recovery_action())
     {
         uint8_t mode = settings_get_wifi_mode();
 
@@ -1030,9 +1044,7 @@ bool Logger_mode_button_long_pushed()
 
 esp_err_t Logger_format_sdcard()
 {
-    if (_currentLogTaskState == LOGTASK_IDLE ||
-        _currentLogTaskState == LOGTASK_ERROR_OCCURED || 
-        _currentLogTaskState == LOGTASK_SINGLE_SHOT)
+    if (Logger_state_allows_recovery_action())
     {
         LoggerState_t t = LOGTASK_FORMAT_SDCARD;
         xQueueSend(xQueue, &t, 1000/portTICK_PERIOD_MS);
@@ -1045,9 +1057,7 @@ esp_err_t Logger_format_sdcard()
 esp_err_t LogTask_start()
 {
     CLEAR_ERRORS(_errorCode);
-    if ((_currentLogTaskState == LOGTASK_IDLE ||
-        _currentLogTaskState == LOGTASK_ERROR_OCCURED || 
-        _currentLogTaskState == LOGTASK_SINGLE_SHOT) && 
+    if (Logger_state_allows_recovery_action() &&
         xQueue != NULL)
     {
         // gpio_set_level(GPIO_ADC_EN, 1);
@@ -1111,8 +1121,7 @@ size_t Logger_flush_buffer_to_sd_card_uint8(uint8_t * buffer, size_t size)
 esp_err_t Logger_calibrate()
 {
     // #ifdef DEBUG_LOGGING
-    if (_currentLogTaskState == LOGTASK_IDLE || 
-        _currentLogTaskState == LOGTASK_SINGLE_SHOT)
+    if (Logger_state_is_settled())
         {
             ESP_LOGI(TAG_LOG, "Logger_calibrate() called");
 
@@ -1363,8 +1372,7 @@ esp_err_t Logger_flush_to_sdcard()
 
 esp_err_t Logger_startFWupdate()
 {
-    if (((_currentLogTaskState == LOGTASK_IDLE) ||
-        (_currentLogTaskState == LOGTASK_SINGLE_SHOT)))
+    if (Logger_state_is_settled())
     // if (xSemaphoreTake(idle_state, 1000 / portTICK_PERIOD_MS) != pdTRUE)
     {
        // #ifdef DEBUG_LOGGING
@@ -2370,10 +2378,9 @@ void task_logging(void * pvParameters)
             ESP_LOGI(TAG_LOG, "Received task: %d", _currentLogTaskState);
         }
 
-        if (gpio_get_level(GPIO_EXT_PIN) && 
-            (_currentLogTaskState == LOGTASK_IDLE ||
-            _currentLogTaskState == LOGTASK_SINGLE_SHOT) && 
-            settings_get_ext_trigger_mode() == TRIGGER_MODE_EXTERNAL_CONTROL && 
+        if (gpio_get_level(GPIO_EXT_PIN) &&
+            Logger_state_is_settled() &&
+            settings_get_ext_trigger_mode() == TRIGGER_MODE_EXTERNAL_CONTROL &&
             _startLogTask == 0 && 
             _systemTimeSet == 1) // first set the system time, else we get the wrong date in our filename
             {

--- a/main/logger.c
+++ b/main/logger.c
@@ -982,34 +982,50 @@ void Logger_mode_button_pushed()
 
 }
 
-void Logger_mode_button_long_pushed()
+bool Logger_mode_button_long_pushed()
 {
     if (_currentLogTaskState == LOGTASK_IDLE ||
         _currentLogTaskState == LOGTASK_ERROR_OCCURED ||
         _currentLogTaskState == LOGTASK_SINGLE_SHOT)
     {
         uint8_t mode = settings_get_wifi_mode();
-        if (mode == WIFI_MODE_APSTA || mode == WIFI_MODE_STA)
+
+        // Recovery gesture: reset all access credentials to their defaults
+        // (empty = open hotspot / no web auth) so a user who locked
+        // themselves out can always get back into the device. This must work
+        // in EVERY mode -- including AP-only, which is the most common
+        // lockout case (a hotspot password was set and forgotten).
+        settings_set_wifi_password("");      // STA / client network
+        settings_set_wifi_password_ap("");   // device's own hotspot
+        settings_set_web_password("");        // web UI HTTP auth
+
+        settings_set_wifi_mode(WIFI_MODE_AP);
+        #ifdef DEBUG_LOGTASK
+        ESP_LOGI(TAG_LOG, "Resetting credentials and switching to AP mode");
+        #endif
+
+        LoggerState_t t = LOGTASK_PERSIST_SETTINGS;
+        xQueueSend(xQueue, &t, 1000/portTICK_PERIOD_MS);
+
+        wifi_disconnect_ap();
+
+        // If we weren't already AP-only, put the driver into a mode that has
+        // an AP interface up so the user has an immediate recovery path
+        // without a reboot.
+        if (mode != WIFI_MODE_AP)
         {
-            settings_set_wifi_mode(WIFI_MODE_AP);
-            #ifdef DEBUG_LOGTASK
-            ESP_LOGI(TAG_LOG, "Switching to AP mode");
-            #endif
-
-            LoggerState_t t = LOGTASK_PERSIST_SETTINGS;
-            xQueueSend(xQueue, &t, 1000/portTICK_PERIOD_MS);
-
-            wifi_disconnect_ap();
-
-            // For STA-only fallback, the driver must be put back into a
-            // mode that has an AP interface; otherwise the user has no
-            // recovery path until the next reboot.
-            if (mode == WIFI_MODE_STA)
-            {
-                wifi_change_mode(WIFI_MODE_AP);
-            }
+            wifi_change_mode(WIFI_MODE_AP);
         }
+
+        // wifi_change_mode() only sets the mode, not the AP credentials.
+        // Re-apply the (now cleared) AP config so the live hotspot drops its
+        // password and becomes open immediately, without a reboot.
+        wifi_update_ap();
+
+        return true;
     }
+
+    return false;
 }
 
 esp_err_t Logger_format_sdcard()

--- a/main/logger.c
+++ b/main/logger.c
@@ -984,27 +984,32 @@ void Logger_mode_button_pushed()
 
 void Logger_mode_button_long_pushed()
 {
-    if (_currentLogTaskState == LOGTASK_IDLE || 
+    if (_currentLogTaskState == LOGTASK_IDLE ||
         _currentLogTaskState == LOGTASK_ERROR_OCCURED ||
         _currentLogTaskState == LOGTASK_SINGLE_SHOT)
     {
-        if (settings_get_wifi_mode()==WIFI_MODE_APSTA)
+        uint8_t mode = settings_get_wifi_mode();
+        if (mode == WIFI_MODE_APSTA || mode == WIFI_MODE_STA)
         {
             settings_set_wifi_mode(WIFI_MODE_AP);
             #ifdef DEBUG_LOGTASK
             ESP_LOGI(TAG_LOG, "Switching to AP mode");
             #endif
-            
-            
-            // Push to queueu
-            // settings_persist_settings();
+
             LoggerState_t t = LOGTASK_PERSIST_SETTINGS;
             xQueueSend(xQueue, &t, 1000/portTICK_PERIOD_MS);
 
             wifi_disconnect_ap();
+
+            // For STA-only fallback, the driver must be put back into a
+            // mode that has an AP interface; otherwise the user has no
+            // recovery path until the next reboot.
+            if (mode == WIFI_MODE_STA)
+            {
+                wifi_change_mode(WIFI_MODE_AP);
+            }
         }
     }
-   
 }
 
 esp_err_t Logger_format_sdcard()

--- a/main/logger.h
+++ b/main/logger.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 #include "settings.h"
@@ -261,7 +262,7 @@ uint8_t Logger_setCsvLog(log_mode_t value);
 uint8_t Logger_getCsvLog();
 
 uint8_t Logger_mode_button();
-void Logger_mode_button_long_pushed();
+bool Logger_mode_button_long_pushed();
 void Logger_mode_button_pushed();
 esp_err_t Logger_syncSettings(uint8_t syncTime);
 // External function to be called outside logger task

--- a/main/rest_server.c
+++ b/main/rest_server.c
@@ -1063,7 +1063,14 @@ static esp_err_t logger_setConfig_handler(httpd_req_t *req)
             json_send_resp(req, ENDPOINT_RESP_NACK, "Error setting Wifi channel", HTTPD_400_BAD_REQUEST);
             goto error;
         }
-        ap_update_required = true;
+        // Only restart the AP if the channel actually changed; otherwise a
+        // "Save all settings" that merely echoes the current channel would
+        // needlessly deauth the connected client. Mirrors the STA-reconnect
+        // change-check below.
+        if (oldSettings.wifi_channel != settings_get_wifi_channel())
+        {
+            ap_update_required = true;
+        }
     }
 
     item = cJSON_GetObjectItemCaseSensitive(settings_in, "WIFI_PASSWORD");
@@ -1084,7 +1091,11 @@ static esp_err_t logger_setConfig_handler(httpd_req_t *req)
             json_send_resp(req, ENDPOINT_RESP_NACK, "Error setting AP password. Must be empty (open) or 8-63 characters.", HTTPD_400_BAD_REQUEST);
             goto error;
         }
-        ap_update_required = true;
+        // Only restart the AP if the password actually changed (see above).
+        if (strcmp(oldSettings.wifi_password_ap, settings_get_wifi_password_ap()) != 0)
+        {
+            ap_update_required = true;
+        }
     }
 
     item = cJSON_GetObjectItemCaseSensitive(settings_in, "WEB_PASSWORD");

--- a/main/rest_server.c
+++ b/main/rest_server.c
@@ -235,6 +235,7 @@ static esp_err_t rest_common_get_handler(httpd_req_t *req)
 
     char *chunk = rest_context->scratch;
     ssize_t read_bytes;
+    size_t total_sent = 0;  // diagnostic: how far we got before any stall
     do {
         /* Read file in chunks into the scratch buffer */
         read_bytes = read(fd, chunk, SCRATCH_BUFSIZE);
@@ -244,13 +245,15 @@ static esp_err_t rest_common_get_handler(httpd_req_t *req)
             /* Send the buffer contents as HTTP response chunk */
             if (httpd_resp_send_chunk(req, chunk, read_bytes) != ESP_OK) {
                 close(fd);
-                ESP_LOGE(REST_TAG, "File sending failed!");
+                ESP_LOGE(REST_TAG, "File sending failed: %s (sent %u bytes before stall)",
+                         filepath, (unsigned)total_sent);
                 /* Abort sending file */
                 httpd_resp_sendstr_chunk(req, NULL);
                 /* Respond with 500 Internal Server Error */
                 httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to send file");
                 return ESP_FAIL;
             }
+            total_sent += read_bytes;
         }
     } while (read_bytes > 0);
     /* Close file after sending complete */
@@ -1401,7 +1404,17 @@ esp_err_t start_rest_server(const char *base_path)
     server = NULL;
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.max_uri_handlers = 18;
-    config.task_priority = tskIDLE_PRIORITY+1;
+    // The default httpd task priority (tskIDLE_PRIORITY+1) is the lowest in the
+    // system, so it gets starved by the logger/WiFi tasks and is slow to drain
+    // socket sends. Bump it so responses keep flowing under load.
+    config.task_priority = tskIDLE_PRIORITY+5;
+    // esp_http_server is single-threaded: a blocking send/recv on one stalled
+    // client socket wedges the whole server for the full timeout. The default
+    // is 5s, so an abandoned connection (e.g. the browser navigating away
+    // mid-load while the device is busy calibrating) freezes all other
+    // requests for 5s at a time. Shorten it so the server recovers quickly.
+    config.send_wait_timeout = 2;
+    config.recv_wait_timeout = 2;
     config.uri_match_fn = httpd_uri_match_wildcard;
     // enable the next in order to prevent occasional http response freezes
     config.lru_purge_enable = true;

--- a/main/settings.c
+++ b/main/settings.c
@@ -1294,7 +1294,7 @@ uint8_t settings_get_wifi_mode()
 
 esp_err_t settings_set_wifi_mode(uint8_t mode)
 {
-    if (mode == WIFI_MODE_APSTA || mode == WIFI_MODE_AP)
+    if (mode == WIFI_MODE_APSTA || mode == WIFI_MODE_AP || mode == WIFI_MODE_STA)
     {
         _settings.wifi_mode = mode;
         return ESP_OK;

--- a/main/settings.h
+++ b/main/settings.h
@@ -26,8 +26,9 @@
 #define FILE_NAME_MODE_TIMESTAMP 1
 
 #define MAX_WIFI_SSID_LEN 32
-#define MAX_WIFI_PASSW_LEN 20
-#define MAX_WIFI_AP_PASSW_LEN 64  // WPA2 allows up to 63 chars + null
+#define MAX_WIFI_PASSW_LEN 65         // WPA2 allows up to 63 chars + null (+1 slack)
+#define MAX_WIFI_PASSW_LEN_OLD 20     // legacy size — keep for binary migration of Settings_old_t
+#define MAX_WIFI_AP_PASSW_LEN 64      // WPA2 allows up to 63 chars + null
 #define MAX_WEB_PASSWORD_LEN 32
 
 #define NUM_ADC_CHANNELS 8
@@ -203,7 +204,7 @@ struct Settings_old_t {
 	uint8_t logMode;
 	char wifi_ssid[MAX_WIFI_SSID_LEN];
 	char wifi_ssid_ap[MAX_WIFI_SSID_LEN];
-	char wifi_password[MAX_WIFI_PASSW_LEN];
+	char wifi_password[MAX_WIFI_PASSW_LEN_OLD]; // pinned to old size so legacy binary blobs still parse
 	uint8_t wifi_channel;
 	uint8_t wifi_mode;
 	uint32_t timestamp; // time in BCD format

--- a/main/spi_control.c
+++ b/main/spi_control.c
@@ -96,29 +96,25 @@ esp_err_t spi_ctrl_datardy_int(uint8_t value)
         #ifdef DEBUG_SPI_CONTROL
         ESP_LOGI(TAG_SPI_CTRL, "Enabling data_rdy interrupts");
         #endif
-        // Trigger on up and down edges
-        if (gpio_install_isr_service(ESP_INTR_FLAG_IRAM) != ESP_OK)
-        {
-            ESP_LOGE(TAG_SPI_CTRL, "Unable to install ISR service");
-            return ESP_FAIL;
-        }
+        // The GPIO ISR service is a global, install-once resource and is
+        // installed in spi_ctrl_init(). Here we only (re)attach the per-pin
+        // handler for the data-ready line.
         // gpio_set_intr_type(GPIO_DATA_RDY_PIN, GPIO_INTR_POSEDGE) == ESP_OK &&
         if (gpio_isr_handler_add(GPIO_DATA_RDY_PIN, gpio_handshake_isr_handler, NULL) != ESP_OK)
         {
             ESP_LOGE(TAG_SPI_CTRL, "Unable to add ISR handler");
             return ESP_FAIL;
         }
-    
+
         return ESP_OK;
     } else if (value == 0) {
         #ifdef DEBUG_SPI_CONTROL
         ESP_LOGI(TAG_SPI_CTRL, "Removing ISR handler" );
         #endif
+        // Only detach the per-pin handler. The global ISR service stays
+        // installed for the lifetime of the application (see spi_ctrl_init()),
+        // so we never uninstall it here.
         gpio_isr_handler_remove(GPIO_DATA_RDY_PIN);
-        #ifdef DEBUG_SPI_CONTROL
-        ESP_LOGI(TAG_SPI_CTRL, "Uninstalling ISR service");
-        #endif
-        gpio_uninstall_isr_service();
         return ESP_OK;
     } else {
         return ESP_FAIL;
@@ -165,6 +161,17 @@ esp_err_t spi_ctrl_init(uint8_t spicontroller, uint8_t gpio_data_ready_point)
     };
 
     gpio_config(&io_conf);
+
+    // Install the global GPIO ISR service exactly once, for the lifetime of
+    // the application. Logging start/stop only adds/removes the per-pin
+    // handler (see spi_ctrl_datardy_int), so the service is never uninstalled.
+    // ESP_ERR_INVALID_STATE means it was already installed, which is fine.
+    ret = gpio_install_isr_service(ESP_INTR_FLAG_IRAM);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE)
+    {
+        ESP_LOGE(TAG_SPI_CTRL, "Unable to install ISR service");
+        return ESP_FAIL;
+    }
 
     gpio_set_drive_capability(STM32_SPI_MOSI, GPIO_DRIVE_CAP_3);
     gpio_set_drive_capability(STM32_SPI_SCLK, GPIO_DRIVE_CAP_3);

--- a/main/sysinfo.h
+++ b/main/sysinfo.h
@@ -8,7 +8,7 @@
 
 #include "esp_system.h"
 
-static const char SW_VERSION[] =  "1.2.1_2026.05.22.11.19";
+static const char SW_VERSION[] =  "1.3.1_2026.06.02.22.02";
 
 // float sysinfo_get_core_temperature();
 const char * sysinfo_get_fw_version();

--- a/main/wifi.c
+++ b/main/wifi.c
@@ -108,10 +108,10 @@ static void wifi_event_handler(void* arg, esp_event_base_t event_base,
         // Only when in STA mode, we try to reconnect
         // Else when changing from STA to APSTA mode,
         // we keep connecting after a disconnect.
-		if (settings_get_wifi_mode() == WIFI_MODE_APSTA) 
+		if (settings_get_wifi_mode() == WIFI_MODE_APSTA ||
+            settings_get_wifi_mode() == WIFI_MODE_STA)
         {
             esp_wifi_connect();
-            // Logtask_wifi_connect_ap();s
         }
 		xEventGroupClearBits(wifi_event_group, CONNECTED_BIT | FAIL_BIT);
 
@@ -329,7 +329,14 @@ esp_err_t wifi_start()
 
     wifi_enabled = 1;
 
-     if (settings_get_wifi_mode() == WIFI_MODE_APSTA) {
+     uint8_t mode = settings_get_wifi_mode();
+
+     // Apply the configured mode after AP config has been stored, so a
+     // runtime switch (e.g. via long-press to fall back to AP) still has
+     // a valid AP config waiting in the driver.
+     ESP_ERROR_CHECK(esp_wifi_set_mode(mode));
+
+     if (mode == WIFI_MODE_APSTA || mode == WIFI_MODE_STA) {
         #ifdef DEBUG_WIFI
         ESP_LOGI(TAG, "Connecting with AP");
         #endif
@@ -359,6 +366,32 @@ esp_err_t wifi_update_ap()
     }
 
     return esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
+}
+
+esp_err_t wifi_change_mode(uint8_t new_mode)
+{
+    if (new_mode != WIFI_MODE_AP &&
+        new_mode != WIFI_MODE_STA &&
+        new_mode != WIFI_MODE_APSTA)
+    {
+        return ESP_FAIL;
+    }
+
+    esp_err_t err = esp_wifi_set_mode((wifi_mode_t)new_mode);
+    if (err != ESP_OK) return err;
+
+    // If the new mode includes STA, kick off a connection attempt.
+    // If it's AP-only, make sure any pending STA connection is dropped.
+    if (new_mode == WIFI_MODE_APSTA || new_mode == WIFI_MODE_STA)
+    {
+        wifi_connect_to_ap();
+    }
+    else
+    {
+        esp_wifi_disconnect();
+    }
+
+    return ESP_OK;
 }
 
 int8_t wifi_get_rssi()

--- a/main/wifi.h
+++ b/main/wifi.h
@@ -37,4 +37,10 @@ esp_err_t wifi_start();
 /// @return ESP_OK if succesfull, ESP_FAIL if not.
 esp_err_t wifi_update_ap();
 
+/// @brief Switches the WiFi mode at runtime (AP, APSTA, or STA).
+/// Updates the ESP-IDF driver mode and reconnects/disconnects as needed.
+/// @param new_mode WIFI_MODE_AP, WIFI_MODE_STA, or WIFI_MODE_APSTA
+/// @return ESP_OK if succesfull, ESP_FAIL if not.
+esp_err_t wifi_change_mode(uint8_t new_mode);
+
 #endif

--- a/update_version.py
+++ b/update_version.py
@@ -5,7 +5,7 @@ import os
 # Define major, minor, patch version numbers
 MAJOR = 1
 MINOR = 3
-PATCH = 0
+PATCH = 1
 
 # Get the directory where the script is located
 script_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
## Summary

Release **1.3.1**. Adds a true Wi-Fi client (STA-only) mode, makes the mode-button long-press a complete credential-recovery gesture, and fixes several stability/robustness issues found during testing (SoftAP restarts, HTTP server stalls, GPIO ISR log spam).

## New features
- **Wi-Fi client (STA-only) mode** — the logger can now join an existing network as a client without running its own hotspot (`WIFI_MODE=2`), selectable as *"Client mode only"* on the Network tab, with runtime mode switching.
- **Longer Wi-Fi client password** — STA passphrase limit raised from 20 → 64 characters for full WPA2 support.

## Improvements & fixes
- **Mode-button long-press is now a full reset** — holding the mode button (~5 s) resets *all* credentials (Wi-Fi client password, hotspot password, web-UI password) and falls back to an open hotspot in **every** Wi-Fi mode (previously only worked in AP/APSTA). The status LED blinks to confirm the reset.
- **No more SoftAP restart on every save** — the access point is only restarted when the AP channel or hotspot password actually changes, so saving unrelated settings (e.g. channel labels) no longer drops your web connection.
- **HTTP server hardened against stalls** — shorter send/recv timeouts and a higher server task priority so a single stalled/abandoned client socket no longer wedges the single-threaded web server; the browser recovers and can reload instead of hanging.
- **GPIO ISR service installed once at init** — eliminates the spurious `GPIO isr service already installed` / `is not installed` log errors around logging start/stop. Interrupt behaviour during logging is unchanged.
- Internal refactor: log-task state guards extracted into named predicates for clarity (behaviour-preserving).

## Version
- Bumped to `1.3.1` (`update_version.py`, `main/sysinfo.h`).

## Testing
All changes were verified on ESP32-S2 hardware: credential reset across AP/STA/APSTA modes, settings saves without AP drop, HTTP server recovery under load, and clean logging start/stop with no ISR log errors.