### PR TITLE
Add option to hide the hotspot SSID

### DIFF
--- a/docs/superpowers/plans/2026-06-04-hide-hotspot-ssid.md
+++ b/docs/superpowers/plans/2026-06-04-hide-hotspot-ssid.md
@@ -1,0 +1,420 @@
+# Hide Hotspot SSID Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a user-configurable option to hide the SoftAP (hotspot) SSID broadcast on the ESP32, exposed as a checkbox in the web config UI.
+
+**Architecture:** A new persisted `uint8_t wifi_ssid_ap_hidden` setting is threaded through the two JSON layers (the lowercase persisted `/spiffs/settings.json` in `settings.c`, and the UPPERCASE REST API in `rest_server.c`), applied at boot to ESP-IDF's built-in `wifi_ap_config_t.ssid_hidden` field. Default is `0` (visible), and the flag takes effect on reset, mirroring the existing Wi-Fi channel setting.
+
+**Tech Stack:** ESP-IDF (C), cJSON, jQuery frontend. No unit-test harness exists — verification is `./build.sh -n` (compile) plus on-device manual checks. Frequent commits per task.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-hide-hotspot-ssid-design.md`
+
+---
+
+## File Structure
+
+- `main/settings.h` — add struct field + getter/setter declarations
+- `main/settings.c` — default, getter/setter, persisted JSON serialize + parse, log
+- `main/wifi.c` — apply `ap.ssid_hidden` in `wifi_start()` and `wifi_update_ap()`
+- `main/rest_server.c` — emit `WIFI_SSID_HIDDEN` in getConfig, parse it in setConfig
+- `front/www/html/config.html` — checkbox + warning note in "Hotspot settings"
+- `front/www/js/config.js` — include `WIFI_SSID_HIDDEN` in the setConfig payload
+- `front/DefaultConfig.json` — add `"WIFI_SSID_HIDDEN": false`
+
+---
+
+## Task 1: Storage layer — persisted setting
+
+**Files:**
+- Modify: `main/settings.h` (struct ~line 194, declarations ~line 299)
+- Modify: `main/settings.c` (default ~line 327, getter/setter ~line 647, parse ~line 926, serialize ~line 1232, print ~line 1147)
+
+- [ ] **Step 1: Add the struct field**
+
+In `main/settings.h`, inside `struct Settings_t` (the CURRENT struct, NOT `Settings_old_t`), add the field at the end of the security settings block. Find:
+
+```c
+	/* Security settings */
+	char wifi_password_ap[MAX_WIFI_AP_PASSW_LEN]; // password for the device's own WiFi AP hotspot
+	char web_password[MAX_WEB_PASSWORD_LEN];       // password for web UI HTTP Basic Auth
+};
+```
+
+Replace with:
+
+```c
+	/* Security settings */
+	char wifi_password_ap[MAX_WIFI_AP_PASSW_LEN]; // password for the device's own WiFi AP hotspot
+	char web_password[MAX_WEB_PASSWORD_LEN];       // password for web UI HTTP Basic Auth
+	uint8_t wifi_ssid_ap_hidden;                   // 0 = SoftAP SSID broadcast (default), 1 = hidden
+};
+```
+
+> Do NOT touch `struct Settings_old_t` — its byte layout must stay frozen for binary migration.
+
+- [ ] **Step 2: Add getter/setter declarations**
+
+In `main/settings.h`, find:
+
+```c
+uint8_t settings_get_wifi_channel();
+esp_err_t settings_set_wifi_channel(uint8_t channel);
+```
+
+Add immediately after:
+
+```c
+uint8_t settings_get_wifi_ssid_ap_hidden();
+esp_err_t settings_set_wifi_ssid_ap_hidden(uint8_t hidden);
+```
+
+- [ ] **Step 3: Initialize the default**
+
+In `main/settings.c`, in `settings_set_default()`, find:
+
+```c
+    _inSettings->wifi_mode = WIFI_MODE_AP;
+    _inSettings->wifi_channel = 1;
+```
+
+Add immediately after:
+
+```c
+    _inSettings->wifi_ssid_ap_hidden = 0; // SoftAP SSID visible by default
+```
+
+- [ ] **Step 4: Implement getter/setter**
+
+In `main/settings.c`, find the `settings_set_wifi_channel` function:
+
+```c
+esp_err_t settings_set_wifi_channel(uint8_t channel)
+{
+    if (channel > 0 && channel < 14)
+    {
+        _settings.wifi_channel = channel;
+        return ESP_OK;
+    } else {
+        return ESP_FAIL;
+    }
+}
+```
+
+Add immediately after it:
+
+```c
+uint8_t settings_get_wifi_ssid_ap_hidden()
+{
+    return _settings.wifi_ssid_ap_hidden;
+}
+
+esp_err_t settings_set_wifi_ssid_ap_hidden(uint8_t hidden)
+{
+    _settings.wifi_ssid_ap_hidden = hidden ? 1 : 0;
+    return ESP_OK;
+}
+```
+
+- [ ] **Step 5: Parse from persisted JSON**
+
+In `main/settings.c`, in `settings_load_json`, find:
+
+```c
+    const cJSON* wifi_channel = cJSON_GetObjectItemCaseSensitive(root, "wifi_channel");
+    if (cJSON_IsNumber(wifi_channel)) {
+        _settings.wifi_channel = wifi_channel->valueint;
+    }
+```
+
+Add immediately after:
+
+```c
+    const cJSON* wifi_ssid_ap_hidden = cJSON_GetObjectItemCaseSensitive(root, "wifi_ssid_ap_hidden");
+    if (cJSON_IsNumber(wifi_ssid_ap_hidden)) {
+        _settings.wifi_ssid_ap_hidden = wifi_ssid_ap_hidden->valueint ? 1 : 0;
+    }
+```
+
+> Missing key is fine — the default from Step 3 (`0`) is already set before load runs, so old `settings.json` files upgrade cleanly.
+
+- [ ] **Step 6: Serialize to persisted JSON**
+
+In `main/settings.c`, find (around line 1232):
+
+```c
+    cJSON_AddNumberToObject(root, "wifi_channel", _settings.wifi_channel);
+    cJSON_AddNumberToObject(root, "wifi_mode", _settings.wifi_mode);
+```
+
+Add immediately after:
+
+```c
+    cJSON_AddNumberToObject(root, "wifi_ssid_ap_hidden", _settings.wifi_ssid_ap_hidden);
+```
+
+- [ ] **Step 7: Log the value (consistency with other Wi-Fi fields)**
+
+In `main/settings.c`, in `settings_print()`, find:
+
+```c
+    ESP_LOGI(TAG_SETTINGS, "Wifi channel %d", _settings.wifi_channel);
+```
+
+Add immediately after:
+
+```c
+    ESP_LOGI(TAG_SETTINGS, "Wifi AP SSID hidden %d", _settings.wifi_ssid_ap_hidden);
+```
+
+- [ ] **Step 8: Build to verify it compiles**
+
+Run: `./build.sh -n`
+Expected: build completes, prints `Output file ota_main.bin and ota_filesystem.bin.` with no compile errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add main/settings.h main/settings.c
+git commit -m "feat(settings): add persisted wifi_ssid_ap_hidden option"
+```
+
+---
+
+## Task 2: Wi-Fi apply — set ap.ssid_hidden
+
+**Files:**
+- Modify: `main/wifi.c` (`wifi_start()` AP block ~line 363, `wifi_update_ap()` AP block ~line 428)
+
+- [ ] **Step 1: Apply in `wifi_start()`**
+
+In `main/wifi.c`, in `wifi_start()`, find:
+
+```c
+    // always default to Uberlogger
+    strcpy((char*)wifi_config.ap.ssid, settings_get_wifi_ssid_ap());
+    wifi_config.ap.ssid_len = strlen((const char*)(wifi_config.ap.ssid));
+    strcpy((char*)wifi_config.ap.password, settings_get_wifi_password_ap());
+```
+
+Add immediately after:
+
+```c
+    wifi_config.ap.ssid_hidden = settings_get_wifi_ssid_ap_hidden();
+```
+
+- [ ] **Step 2: Apply in `wifi_update_ap()`**
+
+In `main/wifi.c`, in `wifi_update_ap()`, find:
+
+```c
+    strcpy((char*)wifi_config.ap.ssid, settings_get_wifi_ssid_ap());
+    wifi_config.ap.ssid_len = strlen((const char*)(wifi_config.ap.ssid));
+    strcpy((char*)wifi_config.ap.password, settings_get_wifi_password_ap());
+
+    if (strlen((const char*)(wifi_config.ap.password)) == 0) {
+        wifi_config.ap.authmode = WIFI_AUTH_OPEN;
+    }
+
+    return esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
+```
+
+Replace with:
+
+```c
+    strcpy((char*)wifi_config.ap.ssid, settings_get_wifi_ssid_ap());
+    wifi_config.ap.ssid_len = strlen((const char*)(wifi_config.ap.ssid));
+    strcpy((char*)wifi_config.ap.password, settings_get_wifi_password_ap());
+    wifi_config.ap.ssid_hidden = settings_get_wifi_ssid_ap_hidden();
+
+    if (strlen((const char*)(wifi_config.ap.password)) == 0) {
+        wifi_config.ap.authmode = WIFI_AUTH_OPEN;
+    }
+
+    return esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `./build.sh -n`
+Expected: build completes with no compile errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/wifi.c
+git commit -m "feat(wifi): apply ssid_hidden to SoftAP config"
+```
+
+---
+
+## Task 3: REST API — getConfig / setConfig
+
+**Files:**
+- Modify: `main/rest_server.c` (getConfig ~line 550, setConfig ~line 1077)
+
+- [ ] **Step 1: Emit the value in getConfig**
+
+In `main/rest_server.c`, in `logger_getConfig_handler` (the response builder), find:
+
+```c
+    cJSON_AddNumberToObject(root, "WIFI_CHANNEL", settings->wifi_channel);
+```
+
+Add immediately after:
+
+```c
+    cJSON_AddBoolToObject(root, "WIFI_SSID_HIDDEN", settings->wifi_ssid_ap_hidden);
+```
+
+> Use `AddBoolToObject` so the frontend checkbox (a `json-as-bool` control) round-trips as a JS boolean, matching `WIFI_PASSWORD_AP_SET` and the channel-enable toggles.
+
+- [ ] **Step 2: Parse the value in setConfig**
+
+In `main/rest_server.c`, in `logger_setConfig_handler`, find the end of the `WIFI_CHANNEL` block:
+
+```c
+        if (oldSettings.wifi_channel != settings_get_wifi_channel())
+        {
+            ap_update_required = true;
+        }
+    }
+```
+
+Add immediately after that closing brace:
+
+```c
+    item = cJSON_GetObjectItemCaseSensitive(settings_in, "WIFI_SSID_HIDDEN");
+    if (item != NULL)
+    {
+        // Takes effect on next reset (mirrors the channel "press reset after
+        // saving" guidance), so we deliberately do NOT set ap_update_required.
+        settings_set_wifi_ssid_ap_hidden(cJSON_IsTrue(item) ? 1 : 0);
+    }
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `./build.sh -n`
+Expected: build completes with no compile errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/rest_server.c
+git commit -m "feat(rest): expose WIFI_SSID_HIDDEN in get/setConfig"
+```
+
+---
+
+## Task 4: Frontend — checkbox, payload, default
+
+**Files:**
+- Modify: `front/www/html/config.html` ("Hotspot settings" group, after the Wi-Fi channel note ~line 502)
+- Modify: `front/www/js/config.js` (setConfig payload object, near `WIFI_CHANNEL` ~line 471)
+- Modify: `front/DefaultConfig.json`
+
+- [ ] **Step 1: Add the checkbox + warning note in config.html**
+
+In `front/www/html/config.html`, find (inside the `wifi_configuration` group):
+
+```html
+        <p class="note" style="margin-top:0"><i><b>Note:</b> Press the reset button manually after saving this setting.</i></p>
+```
+
+Add immediately after:
+
+```html
+        <!-- Hide SSID toggle -->
+        <div class="field-inline" style="margin-top:12px;">
+          <input type="checkbox" name="WIFI_SSID_HIDDEN" id="WIFI_SSID_HIDDEN" value="1" class="json-as-bool" />
+          <label for="WIFI_SSID_HIDDEN">Hide hotspot network name (SSID)</label>
+        </div>
+        <p class="note" style="margin-top:0"><i>When enabled, the hotspot won't appear in Wi-Fi network lists &mdash; you'll need to enter the network name manually to connect. Press the reset button after saving.</i></p>
+```
+
+- [ ] **Step 2: Include the field in the setConfig payload**
+
+In `front/www/js/config.js`, in `setConfig()`, find:
+
+```js
+    WIFI_CHANNEL: input["WIFI_CHANNEL"],
+```
+
+Add immediately after:
+
+```js
+    WIFI_SSID_HIDDEN: input["WIFI_SSID_HIDDEN"],
+```
+
+> Loading needs no change: `parseConfig` already calls `populateFields("#configuration", data)`, which will check the box when getConfig returns `WIFI_SSID_HIDDEN: true`.
+
+- [ ] **Step 3: Add the default to DefaultConfig.json**
+
+In `front/DefaultConfig.json`, find:
+
+```json
+	"WIFI_SSID": "wifi network name",
+	"WIFI_PASSWORD": "wifi password",
+```
+
+Add immediately after:
+
+```json
+	"WIFI_SSID_HIDDEN": false,
+```
+
+- [ ] **Step 4: Build to verify the filesystem image builds**
+
+Run: `./build.sh -n`
+Expected: build completes, including the `www.bin` / `ota_filesystem.bin` step, with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add front/www/html/config.html front/www/js/config.js front/DefaultConfig.json
+git commit -m "feat(ui): add hide-hotspot-SSID toggle to config page"
+```
+
+---
+
+## Task 5: On-device manual verification
+
+**Files:** none (flash + observe)
+
+- [ ] **Step 1: Flash the device**
+
+Run: `./build.sh` (flashes to `/dev/ttyACM0`)
+Expected: build + flash succeed; device reboots.
+
+- [ ] **Step 2: Round-trip the toggle**
+
+1. Open the config page, go to "Hotspot settings".
+2. Check "Hide hotspot network name (SSID)", click Save.
+3. Reload the config page.
+   Expected: the checkbox is still checked (value persisted via getConfig).
+4. Uncheck it, Save, reload.
+   Expected: checkbox is unchecked.
+
+- [ ] **Step 3: Verify broadcast behavior**
+
+1. With the toggle ON and saved, press the device reset button.
+2. From a phone/laptop, scan for Wi-Fi networks.
+   Expected: the `Uberlogger-XXXX` hotspot does NOT appear in the list.
+3. Manually add a network with the exact SSID and connect.
+   Expected: connection succeeds.
+4. Turn the toggle OFF, save, reset, scan again.
+   Expected: the hotspot appears in the scan list normally.
+
+- [ ] **Step 4: Verify upgrade safety (optional, if a pre-update device is available)**
+
+Flash onto a device that already has a `settings.json` lacking the key.
+Expected: device boots with the hotspot visible (default `0`), no settings corruption, serial log shows `Wifi AP SSID hidden 0`.
+
+---
+
+## Notes for the implementer
+
+- There is no automated test suite; "build to verify" means a clean `./build.sh -n` compile. Treat any compiler warning/error in the touched files as a failing step.
+- The two JSON layers are independent and both required: lowercase `wifi_ssid_ap_hidden` (persisted file, Task 1) and UPPERCASE `WIFI_SSID_HIDDEN` (REST API, Task 3). Do not collapse them.
+- `wifi_ap_config_t.ssid_hidden` is a standard ESP-IDF field — no struct definition or include change is needed.

--- a/docs/superpowers/specs/2026-06-04-hide-hotspot-ssid-design.md
+++ b/docs/superpowers/specs/2026-06-04-hide-hotspot-ssid-design.md
@@ -1,0 +1,114 @@
+# Hide Hotspot SSID — Design
+
+**Date:** 2026-06-04
+**Status:** Approved (design)
+
+## Goal
+
+Add a user-configurable option to hide the SoftAP (hotspot) SSID broadcast. When
+enabled, the UberLogger's own Wi-Fi hotspot stops broadcasting its network name,
+so it will not appear in device Wi-Fi scan lists. Users must then enter the SSID
+manually to connect. Default is **off** (SSID visible), preserving current behavior.
+
+## Decisions
+
+- **Apply timing:** takes effect **on reset**, mirroring the existing Wi-Fi
+  channel setting. The value is persisted and applied at boot in `wifi_start()`.
+  No live re-apply (`wifi_update_ap()`) path is added for this flag.
+- **UX:** an italic warning note is shown next to the toggle, plus reuse of the
+  existing "Press the reset button manually after saving this setting" guidance.
+
+## Architecture — four layers
+
+The system has **two distinct JSON layers** that both carry settings, and they
+must not be confused:
+
+1. **Persisted settings file** (`/spiffs/settings.json`) — handled in
+   `main/settings.c`, uses **lowercase** keys (e.g. `wifi_channel`). This is how
+   a setting survives reboot.
+2. **REST API** (`/ajax/getConfig`, `/ajax/setConfig`) — handled in
+   `main/rest_server.c`, uses **UPPERCASE** keys (e.g. `WIFI_CHANNEL`). This is
+   the frontend round-trip.
+
+ESP-IDF's `wifi_ap_config_t` already exposes a `.ssid_hidden` field (0 = visible,
+1 = hidden), so the firmware work is plumbing, not protocol design.
+
+### Layer 1 — Storage (`main/settings.h`, `main/settings.c`)
+
+- Add `uint8_t wifi_ssid_ap_hidden;` to `struct Settings_t` (the current struct).
+  **Do NOT** add it to `struct Settings_old_t` — that legacy binary blob layout
+  must stay byte-frozen for migration to keep working.
+- `settings_set_default()`: initialize `wifi_ssid_ap_hidden = 0`.
+- Getter/setter: `uint8_t settings_get_wifi_ssid_ap_hidden(void)` and
+  `esp_err_t settings_set_wifi_ssid_ap_hidden(uint8_t value)`.
+- Persisted JSON **serialize** (`settings_persist_settings` / cJSON build,
+  near the other `cJSON_AddNumberToObject(root, "wifi_channel", ...)`):
+  add `cJSON_AddNumberToObject(root, "wifi_ssid_ap_hidden", _settings.wifi_ssid_ap_hidden);`
+- Persisted JSON **parse** (`settings_load_json`, near the `wifi_channel` parse):
+  read `"wifi_ssid_ap_hidden"` as a number into `_settings.wifi_ssid_ap_hidden`.
+- Optionally log it in `settings_print()` alongside the other Wi-Fi fields.
+
+### Layer 2 — Wi-Fi apply (`main/wifi.c`)
+
+- In the AP config block of `wifi_start()` (and `wifi_update_ap()` for
+  consistency), set:
+  `wifi_config.ap.ssid_hidden = settings_get_wifi_ssid_ap_hidden();`
+- No new live-restart trigger is wired — the flag is read fresh on each boot.
+
+### Layer 3 — REST API (`main/rest_server.c`)
+
+- **getConfig** (`logger_getConfig_handler`, near
+  `cJSON_AddNumberToObject(root, "WIFI_CHANNEL", ...)`):
+  add `cJSON_AddNumberToObject(root, "WIFI_SSID_HIDDEN", settings->wifi_ssid_ap_hidden);`
+- **setConfig** (`logger_setConfig_handler`, near the `WIFI_CHANNEL` parse):
+  read `"WIFI_SSID_HIDDEN"`, call `settings_set_wifi_ssid_ap_hidden(item->valueint)`.
+  Because timing is "on reset", do **not** set `ap_update_required` for this flag.
+
+### Layer 4 — Frontend (`front/www/html/config.html`, `front/www/js/config.js`, `front/DefaultConfig.json`)
+
+- **config.html:** in the "Hotspot settings" group, add a checkbox
+  `id="WIFI_SSID_HIDDEN" name="WIFI_SSID_HIDDEN"` (class consistent with other
+  boolean/number inputs so `populateFields` and the save path treat it as a
+  number — 0/1). Add an italic note: *"When enabled, the hotspot won't appear in
+  Wi-Fi network lists — you'll need to enter the network name manually to
+  connect."*
+- **config.js:** include `WIFI_SSID_HIDDEN: input["WIFI_SSID_HIDDEN"]` (as a
+  number, 0/1) in the `setConfig()` payload object. Loading is handled by the
+  existing `populateFields("#configuration", data)` since getConfig now returns
+  the `WIFI_SSID_HIDDEN` key.
+- **DefaultConfig.json:** add `"WIFI_SSID_HIDDEN": 0` so "Load defaults" works.
+
+## Data flow
+
+Checkbox → setConfig (UPPERCASE `WIFI_SSID_HIDDEN`) → rest_server parse →
+`settings_set_wifi_ssid_ap_hidden` → `settings_persist_settings` writes lowercase
+`wifi_ssid_ap_hidden` to `/spiffs/settings.json`. On next boot, `wifi_start()`
+reads it and sets `ap.ssid_hidden`. Display is the reverse: getConfig emits
+`WIFI_SSID_HIDDEN`, the checkbox is populated from it.
+
+## Migration / compatibility
+
+No special migration code and no `SETTINGS_FORMAT_VERSION` bump required:
+
+- Current format is JSON, parsed key-by-key. `settings_set_default()` runs before
+  any load and sets the field to `0`; `settings_load_json()` overrides only keys
+  present in the file, so an old `settings.json` lacking the key keeps `0`.
+- The legacy binary path (`settings_migrate`) never references the new field, so
+  it also keeps the default `0`.
+
+## Error handling
+
+- `settings_set_wifi_ssid_ap_hidden` validates/normalizes input to 0 or 1.
+- setConfig treats a missing `WIFI_SSID_HIDDEN` key as "no change" (consistent
+  with other optional keys) — it does not error.
+
+## Testing
+
+- Build firmware via `build.sh` — must compile cleanly.
+- Round-trip: enable the toggle, save, reload the config page → checkbox is
+  checked; disable, save, reload → unchecked.
+- Behavioral: after a reset with the toggle on, the hotspot does not appear in a
+  Wi-Fi scan, yet is still joinable by manually entering the SSID. With the
+  toggle off, the hotspot broadcasts normally.
+- Upgrade safety: a device with a pre-existing `settings.json` (no key) boots
+  with the hotspot visible (default 0).

--- a/front/DefaultConfig.json
+++ b/front/DefaultConfig.json
@@ -6,6 +6,7 @@
 
 	"WIFI_SSID": "wifi network name",
 	"WIFI_PASSWORD": "wifi password",
+	"WIFI_SSID_HIDDEN": false,
 
 	"ENABLE_CONFIGPAGE": 1,
     "CONFIGPAGE_PASSWORD": "",

--- a/front/www/ajax/getConfig.json
+++ b/front/www/ajax/getConfig.json
@@ -2,6 +2,7 @@
   "TIMESTAMP": 1673607089000,
   "WIFI_MODE": 1,
   "WIFI_SSID": "test wifi",
+  "WIFI_SSID_HIDDEN": false,
   "WIFI_PASSWORD_SET": true,
   "WIFI_PASSWORD_AP_SET": false,
   "WEB_PASSWORD_SET": false,

--- a/front/www/ajax/getDefaultConfig.json
+++ b/front/www/ajax/getDefaultConfig.json
@@ -2,6 +2,7 @@
   "TIMESTAMP": 1673607089000,
   "WIFI_MODE": 0,
   "WIFI_SSID": "default wifi",
+  "WIFI_SSID_HIDDEN": false,
   "WIFI_PASSWORD": "default password",
   "LOG_MODE": 0,
   "LOG_SAMPLE_RATE": 3,

--- a/front/www/html/config.html
+++ b/front/www/html/config.html
@@ -501,6 +501,13 @@
         </div>
         <p class="note" style="margin-top:0"><i><b>Note:</b> Press the reset button manually after saving this setting.</i></p>
 
+        <!-- Hide SSID toggle -->
+        <div class="field-inline" style="margin-top:12px;">
+          <input type="checkbox" name="WIFI_SSID_HIDDEN" id="WIFI_SSID_HIDDEN" value="1" class="json-as-bool" />
+          <label for="WIFI_SSID_HIDDEN">Hide hotspot network name (SSID)</label>
+        </div>
+        <p class="note" style="margin-top:0"><i>When enabled, the hotspot won't appear in Wi-Fi network lists &mdash; you'll need to enter the network name manually to connect. Press the reset button after saving.</i></p>
+
         <!-- Hotspot security mode + conditional password -->
         <div class="form-grid-container" style="margin-top: 12px;">
           <div class="form-group">

--- a/front/www/js/config.js
+++ b/front/www/js/config.js
@@ -469,6 +469,7 @@ function setConfig() {
     AIN_CHANNEL_LABELS: ainChannelLabels,
     DIO_CHANNEL_LABELS: dioChannelLabels,
     WIFI_CHANNEL: input["WIFI_CHANNEL"],
+    WIFI_SSID_HIDDEN: input["WIFI_SSID_HIDDEN"],
     WIFI_MODE: input["WIFI_MODE"],
     WIFI_SSID: input["WIFI_SSID"],
     TIMESTAMP: Number(new Date()),

--- a/main/logger.c
+++ b/main/logger.c
@@ -1012,6 +1012,7 @@ bool Logger_mode_button_long_pushed()
         settings_set_wifi_password("");      // STA / client network
         settings_set_wifi_password_ap("");   // device's own hotspot
         settings_set_web_password("");        // web UI HTTP auth
+        settings_set_wifi_ssid_ap_hidden(0);  // un-hide hotspot so it reappears in scans
 
         settings_set_wifi_mode(WIFI_MODE_AP);
         #ifdef DEBUG_LOGTASK
@@ -1033,7 +1034,8 @@ bool Logger_mode_button_long_pushed()
 
         // wifi_change_mode() only sets the mode, not the AP credentials.
         // Re-apply the (now cleared) AP config so the live hotspot drops its
-        // password and becomes open immediately, without a reboot.
+        // password (becomes open) and un-hides its SSID immediately, without a
+        // reboot.
         wifi_update_ap();
 
         return true;

--- a/main/rest_server.c
+++ b/main/rest_server.c
@@ -548,6 +548,7 @@ const char * logger_settings_to_json(Settings_t *settings)
     
     cJSON_AddStringToObject(root, "WIFI_SSID", settings->wifi_ssid);
     cJSON_AddNumberToObject(root, "WIFI_CHANNEL", settings->wifi_channel);
+    cJSON_AddBoolToObject(root, "WIFI_SSID_HIDDEN", settings->wifi_ssid_ap_hidden);
     cJSON_AddBoolToObject(root, "WIFI_PASSWORD_SET", strlen(settings->wifi_password) > 0);
     cJSON_AddBoolToObject(root, "WIFI_PASSWORD_AP_SET", strlen(settings->wifi_password_ap) > 0);
     cJSON_AddBoolToObject(root, "WEB_PASSWORD_SET", strlen(settings->web_password) > 0);
@@ -1074,6 +1075,14 @@ static esp_err_t logger_setConfig_handler(httpd_req_t *req)
         {
             ap_update_required = true;
         }
+    }
+
+    item = cJSON_GetObjectItemCaseSensitive(settings_in, "WIFI_SSID_HIDDEN");
+    if (item != NULL)
+    {
+        // Takes effect on next reset (mirrors the channel "press reset after
+        // saving" guidance), so we deliberately do NOT set ap_update_required.
+        settings_set_wifi_ssid_ap_hidden(cJSON_IsTrue(item) ? 1 : 0);
     }
 
     item = cJSON_GetObjectItemCaseSensitive(settings_in, "WIFI_PASSWORD");

--- a/main/settings.c
+++ b/main/settings.c
@@ -325,6 +325,7 @@ esp_err_t settings_set_default(Settings_t * _inSettings)
     strcpy(_inSettings->web_password, "");     // no web UI password by default
     _inSettings->wifi_mode = WIFI_MODE_AP;
     _inSettings->wifi_channel = 1;
+    _inSettings->wifi_ssid_ap_hidden = 0; // SoftAP SSID visible by default
 
     for (int i = 0; i < NUM_ADC_CHANNELS; i++)
     {
@@ -646,6 +647,17 @@ esp_err_t settings_set_wifi_channel(uint8_t channel)
     }
 }
 
+uint8_t settings_get_wifi_ssid_ap_hidden()
+{
+    return _settings.wifi_ssid_ap_hidden;
+}
+
+esp_err_t settings_set_wifi_ssid_ap_hidden(uint8_t hidden)
+{
+    _settings.wifi_ssid_ap_hidden = hidden ? 1 : 0;
+    return ESP_OK;
+}
+
 char * settings_get_wifi_password()
 {
     return _settings.wifi_password;
@@ -925,6 +937,11 @@ esp_err_t settings_load_json(FILE* f)
         _settings.wifi_channel = wifi_channel->valueint;
     }
 
+    const cJSON* wifi_ssid_ap_hidden = cJSON_GetObjectItemCaseSensitive(root, "wifi_ssid_ap_hidden");
+    if (cJSON_IsNumber(wifi_ssid_ap_hidden)) {
+        _settings.wifi_ssid_ap_hidden = wifi_ssid_ap_hidden->valueint ? 1 : 0;
+    }
+
     const cJSON* wifi_mode = cJSON_GetObjectItemCaseSensitive(root, "wifi_mode");
     if (cJSON_IsNumber(wifi_mode)) {
         _settings.wifi_mode = wifi_mode->valueint;
@@ -1145,6 +1162,7 @@ esp_err_t settings_print()
     ESP_LOGI(TAG_SETTINGS, "Wifi SSID %s", _settings.wifi_ssid);
     ESP_LOGI(TAG_SETTINGS, "Wifi AP SSID %s", _settings.wifi_ssid_ap);
     ESP_LOGI(TAG_SETTINGS, "Wifi channel %d", _settings.wifi_channel);
+    ESP_LOGI(TAG_SETTINGS, "Wifi AP SSID hidden %d", _settings.wifi_ssid_ap_hidden);
     
     return ESP_OK;
 }
@@ -1231,6 +1249,7 @@ char * settings_to_json(Settings_t *settings)
     cJSON_AddNumberToObject(root, "settings_format_version", _settings.settings_format_version);
     cJSON_AddNumberToObject(root, "wifi_channel", _settings.wifi_channel);
     cJSON_AddNumberToObject(root, "wifi_mode", _settings.wifi_mode);
+    cJSON_AddNumberToObject(root, "wifi_ssid_ap_hidden", _settings.wifi_ssid_ap_hidden);
     cJSON_AddStringToObject(root, "wifi_ssid", _settings.wifi_ssid);
     cJSON_AddStringToObject(root, "wifi_ssid_ap", _settings.wifi_ssid_ap);
     cJSON_AddStringToObject(root, "wifi_password", _settings.wifi_password);

--- a/main/settings.h
+++ b/main/settings.h
@@ -193,6 +193,7 @@ struct Settings_t {
 	/* Security settings */
 	char wifi_password_ap[MAX_WIFI_AP_PASSW_LEN]; // password for the device's own WiFi AP hotspot
 	char web_password[MAX_WEB_PASSWORD_LEN];       // password for web UI HTTP Basic Auth
+	uint8_t wifi_ssid_ap_hidden;                   // 0 = SoftAP SSID broadcast (default), 1 = hidden
 };
 
 struct Settings_old_t {
@@ -297,6 +298,9 @@ esp_err_t settings_set_logmode(log_mode_t mode);
 
 uint8_t settings_get_wifi_channel();
 esp_err_t settings_set_wifi_channel(uint8_t channel);
+
+uint8_t settings_get_wifi_ssid_ap_hidden();
+esp_err_t settings_set_wifi_ssid_ap_hidden(uint8_t hidden);
 
 char * settings_get_wifi_password();
 esp_err_t settings_set_wifi_password(char *password);

--- a/main/wifi.c
+++ b/main/wifi.c
@@ -296,6 +296,7 @@ esp_err_t wifi_start()
     strcpy((char*)wifi_config.ap.ssid, settings_get_wifi_ssid_ap());
     wifi_config.ap.ssid_len = strlen((const char*)(wifi_config.ap.ssid));
     strcpy((char*)wifi_config.ap.password, settings_get_wifi_password_ap());
+    wifi_config.ap.ssid_hidden = settings_get_wifi_ssid_ap_hidden();
 
     if (strlen((const char*)(wifi_config.ap.password)) == 0) {
         wifi_config.ap.authmode =  WIFI_AUTH_OPEN;
@@ -360,6 +361,7 @@ esp_err_t wifi_update_ap()
     strcpy((char*)wifi_config.ap.ssid, settings_get_wifi_ssid_ap());
     wifi_config.ap.ssid_len = strlen((const char*)(wifi_config.ap.ssid));
     strcpy((char*)wifi_config.ap.password, settings_get_wifi_password_ap());
+    wifi_config.ap.ssid_hidden = settings_get_wifi_ssid_ap_hidden();
 
     if (strlen((const char*)(wifi_config.ap.password)) == 0) {
         wifi_config.ap.authmode = WIFI_AUTH_OPEN;


### PR DESCRIPTION
## Summary

Adds a user-configurable option to **hide the SoftAP (hotspot) SSID**. When enabled, the UberLogger's own Wi-Fi hotspot stops broadcasting its network name, so it won't appear in device Wi-Fi scan lists — users connect by entering the SSID manually. Default is **off** (SSID visible), preserving current behavior.

Maps to ESP-IDF's built-in `wifi_ap_config_t.ssid_hidden` field.

## What changed

- **Settings** (`settings.h/.c`): new persisted `uint8_t wifi_ssid_ap_hidden` (default `0`), getter/setter, and JSON serialize/parse for `/spiffs/settings.json`.
- **Wi-Fi** (`wifi.c`): applies `ap.ssid_hidden` in both `wifi_start()` and `wifi_update_ap()`.
- **REST API** (`rest_server.c`): exposes `WIFI_SSID_HIDDEN` (bool) in `getConfig`, parses it in `setConfig`.
- **Frontend** (`config.html`, `config.js`, `DefaultConfig.json` + dev-server mocks): a checkbox in the *Hotspot settings* section with a warning note that the network must be joined manually.
- **Recovery gesture** (`logger.c`): the mode-button long-press now also resets `wifi_ssid_ap_hidden` to `0` alongside the password clears, so a locked-out user always gets a discoverable hotspot back. `wifi_update_ap()` re-applies it live (no reboot).

## Behavior notes

- The toggle takes effect **on reset**, mirroring the existing Wi-Fi channel setting (UI shows the "press reset after saving" note).
- No settings migration / format-version bump needed: the persisted file is parsed key-by-key, and the default (`0`) is set before load, so existing `settings.json` files upgrade to "visible" cleanly.

## Test plan

Verified end-to-end on hardware (ESP32-S2):

- [x] Builds clean against `develop`.
- [x] `getConfig` returns `WIFI_SSID_HIDDEN: false` by default; AP broadcasts and is in scan lists.
- [x] Setting it `true` + reboot → hotspot no longer broadcasts (confirmed it was absent from a fresh, never-associated client), still joinable by manually entering the SSID.
- [x] Setting back to `false` + reboot → hotspot broadcasts again.
- [x] Mode-button long-press recovery → SSID reappears live (no reboot); `getConfig` confirms `WIFI_SSID_HIDDEN: false`, `WIFI_MODE: AP`, AP password cleared.

Design spec and implementation plan are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)