### PR TITLE
Release v1.3.3

### DIFF
--- a/front/www/js/config.js
+++ b/front/www/js/config.js
@@ -235,7 +235,7 @@ function updateNtpStatus(enabled, lastSync) {
   if (Number(enabled) !== 1) {
     el.textContent = "disabled";
   } else if (Number(lastSync) > 0) {
-    el.textContent = "last sync: " + new Date(Number(lastSync) * 1000).toLocaleString([], { hour12: false });
+    el.textContent = new Date(Number(lastSync) * 1000).toLocaleString([], { hour12: false });
   } else {
     el.textContent = "waiting for first sync…";
   }

--- a/front/www/js/generic.js
+++ b/front/www/js/generic.js
@@ -21,13 +21,54 @@ const HISTORY_STORAGE_KEY = "liveview.history.v1";
 const SAVE_EVERY_MS = 10000;
 let lastHistorySaveAt = 0;
 
+// --- Channel labels ----------------------------------------------------------
+// The live value table and chart legend show the user's configured channel
+// labels (e.g. "Inlet (T1)") instead of the raw reading keys (T1, AIN5, DI1).
+// Labels live in the config, not in getValues, so we fetch them from getConfig
+// and refresh on page load and when switching to the live view (so renames
+// saved on the Config page show up). channelLabels keeps them in config key
+// form: AIN_CHAN_LABEL1..8 for analog/temperature channels, DIO_CHAN_LABEL1..6
+// for digital channels.
+var channelLabels = { ain: {}, dio: {} };
+
+function loadChannelLabels() {
+  $.getJSON("ajax/getConfig", function (cfg) {
+    channelLabels = {
+      ain: cfg && cfg["AIN_CHANNEL_LABELS"] ? cfg["AIN_CHANNEL_LABELS"] : {},
+      dio: cfg && cfg["DIO_CHANNEL_LABELS"] ? cfg["DIO_CHANNEL_LABELS"] : {},
+    };
+  });
+}
+
+// Map a reading's category + channel to "Label (channel)", or the raw channel
+// key when no label is set. T#/AIN# (same physical input) use the analog
+// labels; DI# uses the digital labels.
+function channelDisplayLabel(category, channel) {
+  var m = String(channel).match(/(\d+)$/);
+  if (!m) return channel;
+  var i = m[1];
+  var lbl =
+    category === "DIGITAL"
+      ? channelLabels.dio["DIO_CHAN_LABEL" + i]
+      : channelLabels.ain["AIN_CHAN_LABEL" + i];
+  if (lbl && String(lbl).trim() !== "") return lbl + " (" + channel + ")";
+  return channel;
+}
+
 function storeDataPoint(category, channel, timestamp, value) {
   var inputTime = new Date(timestamp);
   if (inputTime.getFullYear() < 2000) return; // ignore pre-RTC-sync timestamps
 
+  // The map key stays category.channel (stable id for history/persistence); the
+  // trace name is the human label shown in the legend.
   var key = category + "." + channel;
   if (typeof dataPoints[key] == "undefined") {
-    dataPoints[key] = { x: [], y: [], type: "scatter", name: key };
+    dataPoints[key] = {
+      x: [],
+      y: [],
+      type: "scatter",
+      name: channelDisplayLabel(category, channel),
+    };
   }
 
   var series = dataPoints[key];
@@ -171,6 +212,7 @@ function loadPage() {
   // Restore history saved by a previous page load before anything renders, and
   // flush it on exit so a refresh / tab switch keeps the accumulated live data.
   restoreDataPoints();
+  loadChannelLabels(); // fetch channel labels for the live value table + legend
   window.addEventListener("beforeunload", function () {
     saveDataPoints(true);
   });
@@ -233,6 +275,9 @@ function mountPanel(page) {
 // Switch the visible tab. fromHistory suppresses the pushState (used on initial
 // load and on browser back/forward).
 function showPage(page, fromHistory) {
+  // Refresh channel labels when entering the live view so labels renamed on the
+  // Config page are reflected in the value table and chart legend.
+  if (page === "liveview") loadChannelLabels();
   mountPanel(page).always(function () {
     $("#render > .page-panel").hide();
     $("#panel-" + page).show();

--- a/front/www/js/liveview.js
+++ b/front/www/js/liveview.js
@@ -311,10 +311,26 @@ function plotDataPoints() {
         font: { size: 16 },
         x: 0.5,
       },
+      // Hover a signal to read its value; crosshair spikelines drop to the time
+      // and value axes so you can pinpoint where the cursor is.
+      hovermode: "closest",
       xaxis: {
         title: { text: "Time", font: { size: 14 } },
         type: "date",
         rangeslider: { visible: true, thickness: 0.08 },
+        showspikes: true,
+        spikemode: "across",
+        spikesnap: "cursor",
+        spikethickness: 1,
+        spikedash: "dot",
+        spikecolor: "#888",
+      },
+      yaxis: {
+        showspikes: true,
+        spikemode: "across",
+        spikethickness: 1,
+        spikedash: "dot",
+        spikecolor: "#888",
       },
     };
     Plotly.newPlot(divPlot, dataPointsArray, layout, config);

--- a/front/www/js/liveview.js
+++ b/front/www/js/liveview.js
@@ -208,6 +208,17 @@ function updatePlotModeLabel() {
 // appending to them and the chart/rangeslider stay live.
 function clearLiveView() {
   if (typeof clearDataPoints === "function") clearDataPoints();
+  // Re-seed each series with the latest reading so every channel keeps one live
+  // point. Without this the traces are momentarily empty and Plotly drops their
+  // legend entries, so the signal labels vanish until the next poll (~1s later).
+  if (
+    typeof accumulateReadings === "function" &&
+    typeof valuesData !== "undefined" &&
+    valuesData &&
+    valuesData["READINGS"]
+  ) {
+    accumulateReadings(valuesData);
+  }
   followLive = true;
   // New uirevision token => Plotly discards the stale pan/zoom/rangeslider view
   // for this redraw, then keeps preserving the (reset) view on later ticks.

--- a/front/www/js/liveview.js
+++ b/front/www/js/liveview.js
@@ -63,10 +63,15 @@ function renderValueList() {
     let n = 0;
     $.each(category_values["VALUES"], function (channel, channel_value) {
       n++;
-      let truncatedChannel =
-        channel.length > 4 ? channel.substring(0, 4) + ".." : channel;
+      // Show the configured label ("Inlet (T1)") when set, else the raw key.
+      let label =
+        typeof channelDisplayLabel === "function"
+          ? channelDisplayLabel(category, channel)
+          : channel;
+      let displayChannel =
+        label.length > 22 ? label.substring(0, 22) + "…" : label;
 
-      htmlstring += "<tr><td>" + truncatedChannel + "</td>";
+      htmlstring += "<tr><td>" + displayChannel + "</td>";
 
       if (typeof channel_value === "number") {
         if (category === "TEMPERATURE") {
@@ -271,6 +276,14 @@ function applyResponsiveLayout() {
 }
 
 function plotDataPoints() {
+  // Keep each trace's legend name in sync with the latest channel labels, so
+  // labels that load after the first poll (or change on a config save) show up.
+  Object.keys(dataPoints).forEach(function (key) {
+    var dot = key.indexOf(".");
+    if (dot > 0 && typeof channelDisplayLabel === "function") {
+      dataPoints[key].name = channelDisplayLabel(key.slice(0, dot), key.slice(dot + 1));
+    }
+  });
   const dataPointsArray = Object.values(dataPoints);
 
   let config = {

--- a/front/www/js/liveview.js
+++ b/front/www/js/liveview.js
@@ -64,12 +64,12 @@ function renderValueList() {
     $.each(category_values["VALUES"], function (channel, channel_value) {
       n++;
       // Show the configured label ("Inlet (T1)") when set, else the raw key.
-      let label =
+      // Long labels wrap inside the value card via CSS (no truncation here, so
+      // the "(channel)" suffix is never clipped).
+      let displayChannel =
         typeof channelDisplayLabel === "function"
           ? channelDisplayLabel(category, channel)
           : channel;
-      let displayChannel =
-        label.length > 22 ? label.substring(0, 22) + "…" : label;
 
       htmlstring += "<tr><td>" + displayChannel + "</td>";
 

--- a/front/www/view.css
+++ b/front/www/view.css
@@ -373,6 +373,12 @@ input[type="radio"] {
   grid-column: 1 / -1;
   margin: 0 0 4px;
 }
+/* Let long channel labels (e.g. "Inlet_fdgfd_gfdg (T1)") wrap inside the value
+   card instead of overflowing past the box / widening the grid column. */
+#valuelist .block.greybox td:first-child {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
 
 #plot {
   flex-grow: 2;
@@ -1248,4 +1254,11 @@ details summary:hover {
 @media (max-width: 600px) {
   .fw-file-row  { flex-direction: column; align-items: flex-start; }
   .fw-pick-btn  { width: 100%; text-align: center; box-sizing: border-box; }
+}
+
+/* Small screens: the body otherwise keeps a desktop min-width that forces
+   horizontal scrolling on narrow phones (the live-view chart and tables then
+   run off-screen). Let it shrink to the viewport so everything reflows to fit. */
+@media (max-width: 600px) {
+  body { min-width: 0; }
 }

--- a/main/settings.c
+++ b/main/settings.c
@@ -327,8 +327,10 @@ esp_err_t settings_set_default(Settings_t * _inSettings)
     _inSettings->wifi_channel = 1;
     _inSettings->wifi_ssid_ap_hidden = 0; // SoftAP SSID visible by default
 
-    // Network time: on by default, public pool. Only acts when connected as STA.
-    _inSettings->ntp_enabled = 1;
+    // Network time: off by default. A factory device is hotspot-only with no
+    // network to reach, so NTP can't act until the user sets up a Wi-Fi client
+    // connection and enables it. Default server is the public pool.
+    _inSettings->ntp_enabled = 0;
     strcpy(_inSettings->ntp_server, "pool.ntp.org");
 
     for (int i = 0; i < NUM_ADC_CHANNELS; i++)

--- a/main/settings.h
+++ b/main/settings.h
@@ -94,6 +94,13 @@ typedef enum adc_sample_rate_e {
 	ADC_SAMPLE_RATE_50Hz,
 	ADC_SAMPLE_RATE_100Hz,
 	ADC_SAMPLE_RATE_250Hz,
+	/* 250 Hz is the max SUPPORTED rate. The higher rates below were prototyped
+	 * (branch feature/phase2a-protocol-timestamp, 2026-06) but found UNRELIABLE on
+	 * this hardware: at 500/1000 Hz the STM->ESP SPI frame handoff tears under
+	 * concurrent web/API load (single-core ESP32-S2 can't drain SPI + serve HTTP +
+	 * write SD fast enough), and the STM ring overruns. The feature was abandoned.
+	 * Do NOT re-enable these without first solving the SPI-throughput / handoff
+	 * limit (e.g. larger SPI bursts, DMA double-buffering, or a faster link). */
 	// ADC_SAMPLE_RATE_500Hz,
 	// ADC_SAMPLE_RATE_1000Hz,
 	// ADC_SAMPLE_RATE_2500Hz,

--- a/main/sysinfo.h
+++ b/main/sysinfo.h
@@ -8,7 +8,7 @@
 
 #include "esp_system.h"
 
-static const char SW_VERSION[] =  "1.3.2_2026.06.05.20.21";
+static const char SW_VERSION[] =  "1.3.3_2026.06.07.20.26";
 
 // float sysinfo_get_core_temperature();
 const char * sysinfo_get_fw_version();


### PR DESCRIPTION
## Release v1.3.3

Minor fixes and live-view improvements accumulated since v1.3.2.

### Changes
- **Live view: show configured channel labels** in the value table and chart legend (e.g. `Inlet (T1)`), refreshed when entering the live view so renames apply.
- **Live view: Clear keeps signal labels** — re-seeds the latest reading so the legend doesn't blank.
- **Live view: crosshair spikelines + hover value readout** on the chart.
- **Live view: digital inputs render** correctly (0/1) in boxes and on the chart.
- **Mobile: fixed horizontal overflow** (chart/tables ran off-screen) and **long channel labels wrap** inside the value card.
- **Settings: default NTP to disabled** (factory device is hotspot-only).
- **UI: remove duplicate "last sync:" prefix** in the NTP status label.
- Docs: note 500/1000 Hz unreliable on this HW (max 250 Hz); phase2a abandoned.

Merging to `master` triggers CI to build and publish the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)